### PR TITLE
Set apache2 ini location to defined in apache::params::conf_dir

### DIFF
--- a/manifests/ini.pp
+++ b/manifests/ini.pp
@@ -210,7 +210,7 @@ define puphpet::ini (
           $target_file = "${target_dir}/${ini_filename}"
 
           $webserver_ini_location = $real_webserver ? {
-              'apache2' => '/etc/php5/apache2/conf.d',
+              'apache2' => "${apache::params::confd_dir}",
               'cgi'     => '/etc/php5/cgi/conf.d',
               'fpm'     => '/etc/php5/fpm/conf.d',
               undef     => undef,


### PR DESCRIPTION
For me, solved the bug similar to https://github.com/puphpet/puphpet/issues/387, this message was appearing before:

Stderr from the command:

```shell
stdin: is not a tty
Error: Could not set 'link' on ensure: No such file or directory - /etc/php5/apache2/conf.d at 229:/etc/puppet/modules/puphpet/manifests/ini.pp
Error: Could not set 'link' on ensure: No such file or directory - /etc/php5/apache2/conf.d at 229:/etc/puppet/modules/puphpet/manifests/ini.pp
Wrapped exception:
No such file or directory - /etc/php5/apache2/conf.d
Error: /Stage[main]/Main/Puphpet::Ini[xdebug.default_enable]/File[/etc/php5/apache2/conf.d/zzzz_custom.ini]/ensure: change from absent to link failed: Could not set 'link' on ensure: No such file or directory - /etc/php5/apache2/conf.d at 229:/etc/puppet/modules/puphpet/manifests/ini.pp
```

After this commit change (and pointing my Puppetfile to my fork of course), everything went fine: http://asciinema.org/a/7430

My config.yaml is here: https://gist.github.com/rogeriopradoj/8709119