### PR TITLE
Minor fix: Fixes problem with never versions of PHP

### DIFF
--- a/manifests/xhprof.pp
+++ b/manifests/xhprof.pp
@@ -22,7 +22,7 @@ class puphpet::xhprof (
     require => Vcsrepo["${webroot_location}/xhprof"]
   }
 
-  if $::operatingsystem == 'ubuntu' and $php_version == '54' {
+  if $::operatingsystem == 'ubuntu' and $php_version != '53' {
     exec { 'configure xhprof':
       cwd     => "${webroot_location}/xhprof/extension",
       command => 'phpize && ./configure && make && make install',


### PR DESCRIPTION
The PHP version is hard coded to 5.4. On Ubuntu with PHP 5.5 xhprof can not be installed due to this check of ony PHP 5.4.
