### PR TITLE
PECL beta XHProf package in Debian.

### DIFF
--- a/manifests/php/pecl.pp
+++ b/manifests/php/pecl.pp
@@ -30,6 +30,7 @@ define puphpet::php::pecl (
         'debian' => false,
         'ubuntu' => 'ZendOpcache',
       },
+      'xhprof'      => 'xhprof',
     },
     'Redhat' => {
       #


### PR DESCRIPTION
This adds an option to install XHProf in the way similar to other Pecl packages. The current state of XHProf is 'beta\ in Apt. 
