### PR TITLE
Xdebug now can works with IDE on local machine

### DIFF
--- a/files/xdebug_cli_alias.erb
+++ b/files/xdebug_cli_alias.erb
@@ -1,2 +1,2 @@
 #!/bin/bash
-XDEBUG_CONFIG="idekey=xdebug" php -dxdebug.remote_host=`echo $SSH_CLIENT | cut -d "=" -f 2 | awk '{print $1}'` "$@"
+PHP_IDE_CONFIG="serverName=`echo $HOSTNAME`.cli" XDEBUG_CONFIG="idekey=xdebug" /usr/bin/php -didekey=xdebug -dxdebug.remote_autostart=1 -dxdebug.remote_enable=1 -dxdebug.remote_mode=req -dxdebug.remote_host=`echo $SSH_CLIENT | cut -d "=" -f 2 | awk '{print $1}'` "$@"


### PR DESCRIPTION
In current `xdebug` command I can't map virtual paths to my local paths in my IDE (PHPStorm). This change below should allow it, and btw - will turn on xdebug even if it's been turned off from config file.