### PR TITLE
Remove composer run from XHProf.

### DIFF
--- a/manifests/php/pecl.pp
+++ b/manifests/php/pecl.pp
@@ -31,6 +31,7 @@ define puphpet::php::pecl (
       'augeas'        => 'augeas',
       'mcrypt_filter' => 'mcrypt_filter',
       'pdo_user'      => 'pdo_user',
+      'ssh2'          => 'ssh2',
       'zendopcache'   => $::operatingsystem ? {
         'debian' => false,
         'ubuntu' => 'ZendOpcache',

--- a/manifests/ruby/install.pp
+++ b/manifests/ruby/install.pp
@@ -18,7 +18,7 @@ define puphpet::ruby::install (
     }
 
     if $bundler_true == true {
-      $gems_merged = concat($gems, 'bundler')
+      $gems_merged = concat($gems, ['bundler'])
     } else {
       $gems_merged = $gems
     }


### PR DESCRIPTION
There is no composer.json file, because XHProf is download from https://github.com/facebook/xhprof.git.