### PR TITLE
Fixes issue puphpet/puppet-puphpet#14 changed jemalloc download for Cent...

### DIFF
--- a/manifests/hhvm.pp
+++ b/manifests/hhvm.pp
@@ -50,27 +50,15 @@ class puphpet::hhvm(
       }
     }
     'centos': {
-      $jemalloc_url = 'http://files.puphpet.com/centos6/jemalloc-3.6.0-1.el6.x86_64.rpm'
-      $jemalloc_download_location = '/.puphpet-stuff/jemalloc-3.6.0-1.el6.x86_64.rpm'
 
       $require = defined(Class['my_fw::post']) ? {
         true    => Class['my_fw::post'],
         default => [],
       }
 
-      exec { "download jemalloc to ${download_location}":
-        creates => $download_location,
-        command => "wget --quiet --tries=5 --connect-timeout=10 -O '${jemalloc_download_location}' '${jemalloc_url}'",
-        timeout => 30,
-        path    => '/usr/bin',
-        require => $require
-      }
-
       package { 'jemalloc':
         ensure   => latest,
         provider => yum,
-        source   => $download_location,
-        require  => Exec["download jemalloc to ${download_location}"],
       }
 
       yum::managed_yumrepo { 'hop5':


### PR DESCRIPTION
...Os

The old jemalloc rpm no longer exists on files.puphpet.com site, switched to epel
