### PR TITLE
Add nodejs support for 32bit architectures

### DIFF
--- a/manifests/nodejs.pp
+++ b/manifests/nodejs.pp
@@ -2,6 +2,11 @@
 
 class puphpet::nodejs {
 
+  $node_arch = $::hardwaremodel ? {
+    /.*64.*/ => 'x64',
+    default  => 'x86',
+  }
+
   file { '/.puphpet-stuff/node_install.sh':
     ensure  => present,
     owner   => root,

--- a/templates/nodejs/install.erb
+++ b/templates/nodejs/install.erb
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-LATEST_NODE=$(curl 'http://nodejs.org/dist/latest/SHASUMS.txt' | grep 'linux-x64.tar.gz' | awk '{ print $2 }')
+LATEST_NODE=$(curl 'http://nodejs.org/dist/latest/SHASUMS.txt' | grep 'linux-<%= @node_arch -%>.tar.gz' | awk '{ print $2 }')
 wget --quiet --tries=5 --connect-timeout=10 --no-check-certificate -O '/.puphpet-stuff/nodestable.tar.gz' "http://nodejs.org/dist/latest/${LATEST_NODE}"
 
 cd '/usr/local/'


### PR DESCRIPTION
Nodejs installation fails silently on 32-bit systems -- the issue only affects provisioning if you install any npm packages through puppet, otherwise the install appears to finish successfully, but will create non-executable binaries.

Installing an npm package via puppet:

```bash
Error: /Stage[main]/Main/Package[bower]: Could not evaluate: Puppet::Util::Log requires a message
```

Running `node` in the terminal:

```bash
vagrant@system:/usr/local/bin$ node --version
-bash: /usr/local/bin/node: cannot execute binary file: Exec format error
```

Running `npm install` in the terminal:

```bash
vagrant@system:~$ npm install
/usr/local/bin/node: 1: /usr/local/bin/node: ELF: not found
/usr/local/bin/node: 2: /usr/local/bin/node: cannot open 8?
                                                           : No such file
/usr/local/bin/node: 2: /usr/local/bin/node: �K���E�FT: not found
/usr/local/bin/node: 4: /usr/local/bin/node: 2�2�2Ig6K: not found
/usr/local/bin/node: 9: /usr/local/bin/node: Syntax error: redirection unexpected (expecting ")")
/usr/local/bin/node: 1: /usr/local/bin/node: Fu=: not found
/usr/local/bin/node: 9: /usr/local/bin/node: �KLoL: not found
vagrant@gowili:~$ /usr/local/bin/node: 1: /usr/local/bin/node: 1�En@WMhJ!3+�: not found
/usr/local/bin/node: 1: /usr/local/bin/node: 3g,�3N#�B��iKt@5�: not found
/usr/local/bin/node: 1: /usr/local/bin/node: }6d7.7fLk/y8�/�18�
                                                               J�KY=SKq�: not found
/usr/local/bin/node: 1: /usr/local/bin/node: �5�A1F�8: not found
/usr/local/bin/node: 1: /usr/local/bin/node: �: not found
/usr/local/bin/node: 4: /usr/local/bin/node: cannot open �7�h/�D��+8�7y: No such file
```