### PR TITLE
Fix adminer not being installed when postgres and/or nginx are used.

### DIFF
--- a/manifests/adminer/install.pp
+++ b/manifests/adminer/install.pp
@@ -19,7 +19,7 @@ class puphpet::adminer::install
 
   if array_true($nginx, 'install') {
     $webroot = $puphpet::nginx::params::webroot_location
-    $require = Class['puphpet::nginx']
+    $require = Class['puphpet::nginx::install']
   } elsif array_true($apache, 'install') {
     $webroot = $puphpet::apache::params::default_vhost_dir
     $require = Class['puphpet::apache::install']

--- a/manifests/postgresql/install.pp
+++ b/manifests/postgresql/install.pp
@@ -68,4 +68,6 @@ class puphpet::postgresql::install
     grants => $grants,
   }
 
+  include puphpet::postgresql::php
+
 }

--- a/manifests/postgresql/php.pp
+++ b/manifests/postgresql/php.pp
@@ -19,7 +19,7 @@ class puphpet::postgresql::php
     }
   }
 
-  if array_true($mariadb, 'adminer')
+  if array_true($postgresql, 'adminer')
     and $php_package
     and ! defined(Class['puphpet::adminer::install'])
   {


### PR DESCRIPTION
Additionally fixes the https://github.com/puphpet/puphpet/issues/2448 (adminer part). I.e. the following:
```
Error: Could not find dependency Class[Puphpet::Nginx] for Puphpet::Server::Wget[/var/www/html/adminer.php] at /tmp/vagrant-puppet/modules-64729193e604fbfa51b5607d98f788de/puphpet/manifests/adminer/install.pp:39
```