### PR TITLE
Fix python error ('No module named six.moves')

### DIFF
--- a/manifests/python/params.pp
+++ b/manifests/python/params.pp
@@ -14,7 +14,7 @@ class puphpet::python::params
     default => { }
   }
 
-  $setup_tools_url = 'https://bootstrap.pypa.io/ez_setup.py'
-  $setup_tools_download = '/.puphpet-stuff/ez_setup.py'
+  $setup_tools_url = 'https://bootstrap.pypa.io/get-pip.py'
+  $setup_tools_download = '/.puphpet-stuff/get-pip.py'
 
 }

--- a/manifests/python/pip.pp
+++ b/manifests/python/pip.pp
@@ -16,11 +16,9 @@ class puphpet::python::pip {
     user   => 'root',
     group  => 'root',
   }
-  -> exec { 'Install ez_setup':
-    command => "python ${puphpet::python::params::setup_tools_download}",
-    creates => '/usr/local/bin/easy_install',
-  }
   -> exec { 'easy_install pip':
+    command => "python ${puphpet::python::params::setup_tools_download}",
+    creates => '/usr/local/bin/pip',
     unless => 'which pip',
   }
 


### PR DESCRIPTION
The ez-setup.py has been deprecated, and even gives errors on latest versions. Moved to the get-pip.py script instead, which (now) installs setuptools by default anyway. Successfully tested on my local CentOS 7 install.