### PR TITLE
Fix solr supervisor run command

### DIFF
--- a/manifests/solr/install.pp
+++ b/manifests/solr/install.pp
@@ -44,7 +44,7 @@ class puphpet::solr::install {
   $path        = "${destination}/solr-${version}/bin"
 
   supervisord::program { 'solr':
-    command     => "${path}/solr start -p ${settings['port']}",
+    command     => "${path}/solr start -f -p ${settings['port']}",
     priority    => '100',
     user        => 'root',
     autostart   => true,


### PR DESCRIPTION
Update solr run configuration command to run solr in foreground, otherwise supervisor thinks that running the process failed:
solr                             FATAL     Exited too quickly (process log may have details)

Supervisor tries to restart the process a few times (without success as port has been taken) and then gives up reporting that process has failed although the solr is running, one also cannot stop solr thru supervisor as it thinks that the process is already down.
Note: in this state one cannot stop solr thru supervisor.