### PR TITLE
Replaced example domain with awesome.test

### DIFF
--- a/files/webserver_landing.html
+++ b/files/webserver_landing.html
@@ -42,11 +42,11 @@
 
                     <p>
                         Add a line with the IP address of this server and all vhosts you chose. For example, if the
-                        IP address is <code>192.168.100.1</code>, and you chose vhost <code>awesome.dev</code>,
+                        IP address is <code>192.168.100.1</code>, and you chose vhost <code>awesome.test</code>,
                         you will want to enter the following:
                     </p>
 
-                    <pre>192.168.100.1 awesome.dev www.awesome.dev</pre>
+                    <pre>192.168.100.1 awesome.test www.awesome.test</pre>
 
                     <p>
                         If you forgot the IP address you chose, check the config file at


### PR DESCRIPTION
The project seems to have dropped the awesome.dev for the awesome.test domainname. But the default webpage didn't reflect this yet.