### PR TITLE
Update www_root empty check

### DIFF
--- a/manifests/nginx/vhosts.pp
+++ b/manifests/nginx/vhosts.pp
@@ -8,7 +8,7 @@ define puphpet::nginx::vhosts (
 
   each( $vhosts ) |$key, $vhost| {
     # Could be proxy vhost
-    if $vhost['www_root'] != '' {
+    if $vhost['www_root'] != undef {
       $chown = "${puphpet::nginx::params::webroot_user}:${puphpet::nginx::params::webroot_group}"
 
       exec { "exec mkdir -p ${vhost['www_root']} @ key ${key}":


### PR DESCRIPTION
In nginx puppet manifest used in puphpet, a vhost can be generated without `root` instruction if the `www_root` directive isn't set (which, in my case, is useful because the root clause is declared by a including a file using `include_files`).

The problem: as this manifest check for `''` and not `undef`, the check fails on the `if ! defined(File[$vhost['www_root']])` test.

I think PuPHPet website should be updated too to remove `www_root` directive if the value is empty on configurator, but that's over my knowledge of this project.